### PR TITLE
Fix conditional attribute comparsion with Float

### DIFF
--- a/lib/jmespath/nodes/condition.rb
+++ b/lib/jmespath/nodes/condition.rb
@@ -99,7 +99,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value > right_value ? @child.visit(value) : nil
+        left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value > right_value ? @child.visit(value) : nil
       end
     end
 
@@ -109,7 +109,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value >= right_value ? @child.visit(value) : nil
+        left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value >= right_value ? @child.visit(value) : nil
       end
     end
 
@@ -119,7 +119,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value < right_value ? @child.visit(value) : nil
+        left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value < right_value ? @child.visit(value) : nil
       end
     end
 
@@ -129,7 +129,7 @@ module JMESPath
       def visit(value)
         left_value = @left.visit(value)
         right_value = @right.visit(value)
-        left_value.is_a?(Integer) && right_value.is_a?(Integer) && left_value <= right_value ? @child.visit(value) : nil
+        left_value.is_a?(Numeric) && right_value.is_a?(Numeric) && left_value <= right_value ? @child.visit(value) : nil
       end
     end
   end

--- a/spec/compliance/filters.json
+++ b/spec/compliance/filters.json
@@ -81,6 +81,33 @@
     ]
   },
   {
+    "given": {"foo": [{"length": 170},
+      {"length": 175.5},
+      {"length": 185}]},
+    "cases": [
+      {
+        "comment": "Less than number",
+        "expression": "foo[?length < `180`]",
+        "result": [{"length": 170}, {"length": 175.5}]
+      },
+      {
+        "comment": "Less than or equal to number",
+        "expression": "foo[?length <= `175.5`]",
+        "result": [{"length": 170}, {"length": 175.5}]
+      },
+      {
+        "comment": "Greater than number",
+        "expression": "foo[?length > `170`]",
+        "result": [{"length": 175.5}, {"length": 185}]
+      },
+      {
+        "comment": "Greater than or equal to number",
+        "expression": "foo[?length >= `175.5`]",
+        "result": [{"length": 175.5}, {"length": 185}]
+      }
+    ]
+  },
+  {
     "given": {"foo": [{"top": {"name": "a"}},
       {"top": {"name": "b"}}]},
     "cases": [


### PR DESCRIPTION
Currently node greater/less than comparison compares only integers and this PR changes this to work with both integers and Floats like JMESPath.js does.