### PR TITLE
Added executables parameter to gemspec for files in bin/

### DIFF
--- a/jmespath.gemspec
+++ b/jmespath.gemspec
@@ -8,5 +8,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://github.com/trevorrowe/jmespath.rb'
   spec.license       = 'Apache-2.0'
   spec.require_paths = ['lib']
+  spec.executables   = Dir['bin/**'].map &File.method(:basename)
   spec.files         = Dir['lib/**/*.rb'] + ['LICENSE.txt']
 end


### PR DESCRIPTION
.. this is needed so that rubygems knows to create an wrapper in its bin directory to the script so it will be in the user's PATH.